### PR TITLE
Safer SafeAreaPadding.GetTopLevelRect when hierarchy is different

### DIFF
--- a/Runtime/SafeAreaPadding/SafeAreaPadding.cs
+++ b/Runtime/SafeAreaPadding/SafeAreaPadding.cs
@@ -43,8 +43,16 @@ namespace E7.NotchSolution
 
         private Rect GetTopLevelRect()
         {
-            Vector2 topRectSize = transform.root.GetComponent<RectTransform>().sizeDelta;
+            var topLevelCanvas = GetTopLevelCanvas();
+            Vector2 topRectSize = topLevelCanvas.GetComponent<RectTransform>().sizeDelta;
             return new Rect(Vector2.zero, topRectSize);
+            
+            Canvas GetTopLevelCanvas()
+            {
+                var canvas = this.GetComponentInParent<Canvas>();
+                var rootCanvas = canvas.rootCanvas;
+                return rootCanvas;
+            }
         }
 
 #pragma warning disable 0649


### PR DESCRIPTION
I added proper fetching of the root canvas into GetTopLevelRect, so the functionality doesn't break if the Canvas object doesn't happen to be the root object of the entire transform hierarchy.

I organize my stuff in the scene in a way where the root canvas is a child object of an empty game object, so the plugin didn't work for me.