### PR TITLE
Fix #10 + Canvas at the top + User-defined Shortcut

### DIFF
--- a/DebugScene/NotchSolutionDebug.unity.meta
+++ b/DebugScene/NotchSolutionDebug.unity.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2cda990e2423bbf4892e6590ba056729
+guid: 32b560ed26d62b64e9dea03303e03089
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Editor/NoSo-MockupCanvas.prefab
+++ b/Editor/NoSo-MockupCanvas.prefab
@@ -58,7 +58,7 @@ Canvas:
   m_SortingBucketNormalizedSize: 0
   m_AdditionalShaderChannelsFlag: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 5555
+  m_SortingOrder: 32767
   m_TargetDisplay: 0
 --- !u!114 &3673283291737537850
 MonoBehaviour:

--- a/Editor/NotchSimulator.cs
+++ b/Editor/NotchSimulator.cs
@@ -43,7 +43,10 @@ namespace E7.NotchSolution
 
             bool enableSimulation = NotchSimulatorUtility.enableSimulation;
             EditorGUI.BeginChangeCheck();
-            NotchSimulatorUtility.enableSimulation = EditorGUILayout.BeginToggleGroup("Simulate (Alt+N)", NotchSimulatorUtility.enableSimulation);
+
+            string shortcut = ShortcutManager.instance.GetShortcutBinding("Notch Solution/Toggle Notch Simulator").ToString();
+            if (string.IsNullOrEmpty(shortcut)) shortcut = "None";
+            NotchSimulatorUtility.enableSimulation = EditorGUILayout.BeginToggleGroup($"Simulate ({shortcut})", NotchSimulatorUtility.enableSimulation);
             EditorGUI.indentLevel++;
 
             NotchSimulatorUtility.selectedDevice = (SimulationDevice)EditorGUILayout.EnumPopup(NotchSimulatorUtility.selectedDevice);

--- a/Runtime/MockupCanvas.cs
+++ b/Runtime/MockupCanvas.cs
@@ -66,6 +66,10 @@ public class MockupCanvas : MonoBehaviour
                 flipped ? -1 : 1,
                 1
             );
+            
+            //Force refreshing the mockup
+            mockupImage.enabled = false;
+            mockupImage.enabled = true;
         }
     }
 }


### PR DESCRIPTION
This pull request provides a temporary fix of issue #10.
The shortcut displayed in the window is the one defined by the user, not the default one.
I've also set the sorting order of the canvas to the max, so the mock-up is always on top of the scene.