### PR TITLE
Partial support of notches + The debug scene displays the simulated information + Some other changes

### DIFF
--- a/DebugScene/DebugRect.cs
+++ b/DebugScene/DebugRect.cs
@@ -24,12 +24,12 @@ public class DebugRect : MonoBehaviour
         RectTransformUtility.ScreenPointToLocalPointInRectangle(parentRect, screenRect.position, Camera.main, out Vector2 localPoint);
         RectTransformUtility.ScreenPointToLocalPointInRectangle(parentRect, screenRect.size, Camera.main, out Vector2 localSize);
 
-        localSize = localSize + (parentRect.sizeDelta /2);
+        localSize = localSize + (parentRect.sizeDelta / 2);
 
         debugText.text = $"{screenRect}";
-        
+
         rectTransform.localPosition = localPoint;
         rectTransform.sizeDelta = localSize;
-        
+
     }
 }

--- a/DebugScene/NotchSolutionDebugger.cs
+++ b/DebugScene/NotchSolutionDebugger.cs
@@ -27,6 +27,8 @@ public class NotchSolutionDebugger : MonoBehaviour
         var safeArea = Screen.safeArea;
 #endif
         PlaceRect(safeArea, Color.red);
+        if (Screen.orientation != NotchSolutionUtility.GetCurrentOrientation())
+            safeArea.Set(Screen.width - safeArea.x, Screen.height - safeArea.y, safeArea.width, safeArea.height);
         sb.AppendLine($"Safe area : {safeArea}\n");
 
 #if UNITY_2019_2_OR_NEWER
@@ -39,6 +41,11 @@ public class NotchSolutionDebugger : MonoBehaviour
         var cutouts = Screen.cutouts;
 #endif
         foreach (Rect r in cutouts) PlaceRect(r, Color.blue);
+
+        if (Screen.orientation != NotchSolutionUtility.GetCurrentOrientation())
+        {
+            foreach (Rect rect in cutouts) rect.Set(Screen.width - rect.x, Screen.height - rect.y, rect.width, rect.height);
+        }
         sb.AppendLine($"Cutouts : {string.Join(" / ", cutouts.Select(x => x.ToString()))} \n");
 #endif
 

--- a/Editor/EnumButtonsDrawer.cs
+++ b/Editor/EnumButtonsDrawer.cs
@@ -18,5 +18,5 @@ namespace E7.NotchSolution
         }
     }
 
-    
+
 }

--- a/Editor/NotchSimulator.cs
+++ b/Editor/NotchSimulator.cs
@@ -15,6 +15,7 @@ namespace E7.NotchSolution
     public class NotchSimulator : EditorWindow
     {
         internal static NotchSimulator win;
+        Vector2 gameviewResolution;
 
         [MenuItem("Window/General/Notch Simulator")]
         public static void ShowWindow()
@@ -22,6 +23,21 @@ namespace E7.NotchSolution
             win = (NotchSimulator)EditorWindow.GetWindow(typeof(NotchSimulator));
             win.titleContent = new GUIContent("Notch Simulator");
         }
+
+        [ExecuteInEditMode] private void OnEnable() { EditorApplication.update += RespawnMockup; }
+        [ExecuteInEditMode] private void OnDisable() { EditorApplication.update += RespawnMockup; }
+        void RespawnMockup()
+        {
+            //When the game view is changed, the mockup sometimes disappears or isn't scaled correctly
+            if (gameviewResolution != Handles.GetMainGameViewSize())
+            {
+                DestroyHiddenCanvas(); //So we delete the old canvas
+                UpdateAllMockups(); //And we respawn it
+                UpdateSimulatorTargets();
+                gameviewResolution = Handles.GetMainGameViewSize(); //Update the saved game view
+            }
+        }
+
         /// <summary>
         /// It is currently active only when Notch Simulator tab is present.
         /// </summary>

--- a/Editor/NotchSimulator.cs
+++ b/Editor/NotchSimulator.cs
@@ -25,7 +25,7 @@ namespace E7.NotchSolution
         }
 
         [ExecuteInEditMode] private void OnEnable() { EditorApplication.update += RespawnMockup; }
-        [ExecuteInEditMode] private void OnDisable() { EditorApplication.update += RespawnMockup; }
+        [ExecuteInEditMode] private void OnDisable() { EditorApplication.update -= RespawnMockup; }
         void RespawnMockup()
         {
             //When the game view is changed, the mockup sometimes disappears or isn't scaled correctly

--- a/Editor/SafeAreaPaddingDrawer.cs
+++ b/Editor/SafeAreaPaddingDrawer.cs
@@ -75,5 +75,5 @@ namespace E7.NotchSolution
         }
     }
 
-    
+
 }

--- a/Editor/SafeAreaPaddingSidesDrawer.cs
+++ b/Editor/SafeAreaPaddingSidesDrawer.cs
@@ -9,5 +9,5 @@ namespace E7.NotchSolution
 
     [CustomPropertyDrawer(typeof(SafeAreaPaddingOrientationType))]
     public class SafeAreaPaddingOrientationTypeDrawer : EnumButtonsDrawer { }
-    
+
 }

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Please see the Issue section.
 - iPhone X
 - iPad Pro
 
-(Contributed by @06Games)
+(Contributed by [06Games](https://github.com/06Games))
 
 - Huawei Mate 20 Pro 
 - OnePlus 6T

--- a/Runtime/INotchSimulatorTarget.cs
+++ b/Runtime/INotchSimulatorTarget.cs
@@ -4,6 +4,6 @@ namespace E7.NotchSolution
 {
     public interface INotchSimulatorTarget
     {
-        void SimulatorUpdate(Rect simulatedSafeArea);
+        void SimulatorUpdate(Rect simulatedSafeArea, Rect[] simulatedCutouts);
     }
 }

--- a/Runtime/NotchSolutionUtility.cs
+++ b/Runtime/NotchSolutionUtility.cs
@@ -10,11 +10,12 @@ namespace E7.NotchSolution
     {
         public const string prefix = nameof(NotchSolution) + "_";
 
-        private  const string simulateSafeAreaRect = prefix + nameof(simulateSafeAreaRect);
-        private  const string prefabModeOverlayColor = prefix + nameof(prefabModeOverlayColor);
+        private const string simulateSafeAreaRect = prefix + nameof(simulateSafeAreaRect);
+        private const string simulateCutoutsRect = prefix + nameof(simulateCutoutsRect);
+        private const string prefabModeOverlayColor = prefix + nameof(prefabModeOverlayColor);
 
-        private  const string narrowestAspectIndex = prefix + nameof(narrowestAspectIndex);
-        private  const string widestAspectIndex = prefix + nameof(widestAspectIndex);
+        private const string narrowestAspectIndex = prefix + nameof(narrowestAspectIndex);
+        private const string widestAspectIndex = prefix + nameof(widestAspectIndex);
 
 #if UNITY_EDITOR
 
@@ -62,28 +63,52 @@ namespace E7.NotchSolution
         /// </summary>
         public static Rect SimulateSafeAreaRelative
         {
+            get { return ParseRect(EditorPrefs.GetString(simulateSafeAreaRect, "0;0;1;1")); }
+            set { EditorPrefs.SetString(simulateSafeAreaRect, RectToString(value)); }
+        }
+
+#if UNITY_2019_2_OR_NEWER
+        /// <summary>
+        /// These rects are kept in EditorPref so that they survive assembly reload.
+        /// </summary>
+        public static Rect[] SimulateCutoutsRelative
+        {
             get
             {
-                var rectString = EditorPrefs.GetString(simulateSafeAreaRect, "0;0;1;1");
-                var rectStrings = rectString.Split(';');
-                return new Rect(
-                    float.Parse(rectStrings[0]),
-                    float.Parse(rectStrings[1]),
-                    float.Parse(rectStrings[2]),
-                    float.Parse(rectStrings[3])
-                );
+                var rectStrings = EditorPrefs.GetString(simulateCutoutsRect, "").Split(new string[] { "\n" }, System.StringSplitOptions.RemoveEmptyEntries);
+                System.Collections.Generic.List<Rect> rects = new System.Collections.Generic.List<Rect>();
+                foreach (var rectString in rectStrings) rects.Add(ParseRect(rectString));
+                return rects.ToArray();
             }
             set
             {
-                var rectString = string.Join(";", new string[]
-                {
-                    value.xMin.ToString(),
-                    value.yMin.ToString(),
-                    value.width.ToString(),
-                    value.height.ToString(),
-                });
-                EditorPrefs.SetString(simulateSafeAreaRect, rectString);
+                System.Collections.Generic.List<string> rectStrings = new System.Collections.Generic.List<string>();
+                foreach (Rect rect in value) rectStrings.Add(RectToString(rect));
+                EditorPrefs.SetString(simulateCutoutsRect, string.Join("\n", rectStrings));
             }
+        }
+#endif
+
+        static Rect ParseRect(string rectString)
+        {
+            var rect = rectString.Split(';');
+            return new Rect(
+                        float.Parse(rect[0]),
+                        float.Parse(rect[1]),
+                        float.Parse(rect[2]),
+                        float.Parse(rect[3])
+                    );
+        }
+
+        static string RectToString(Rect rect)
+        {
+            return string.Join(";", new string[]
+                    {
+                    rect.xMin.ToString(),
+                    rect.yMin.ToString(),
+                    rect.width.ToString(),
+                    rect.height.ToString(),
+                    });
         }
 
         /// <summary>

--- a/Runtime/NotchSolutionUtility.cs
+++ b/Runtime/NotchSolutionUtility.cs
@@ -36,12 +36,13 @@ namespace E7.NotchSolution
             {
                 var colorString = EditorPrefs.GetString(prefabModeOverlayColor, "0.297;0.405;0.481;1");
                 var colorStrings = colorString.Split(';');
-                return new Color(
-                    float.Parse(colorStrings[0]),
-                    float.Parse(colorStrings[1]),
-                    float.Parse(colorStrings[2]),
-                    float.Parse(colorStrings[3])
-                );
+                Color color = new Color(0.297F, 0.405F, 0.481F, 1);
+                for (int i = 0; i < 4; i++)
+                {
+                    if (float.TryParse(colorStrings[i], out float rgba)) color[i] = rgba;
+                    else return new Color(0.297F, 0.405F, 0.481F, 1);
+                }
+                return color;
             }
             set
             {

--- a/Runtime/SafeAreaPadding/SafeAreaPadding.cs
+++ b/Runtime/SafeAreaPadding/SafeAreaPadding.cs
@@ -48,7 +48,7 @@ namespace E7.NotchSolution
             var topLevelCanvas = GetTopLevelCanvas();
             Vector2 topRectSize = topLevelCanvas.GetComponent<RectTransform>().sizeDelta;
             return new Rect(Vector2.zero, topRectSize);
-            
+
             Canvas GetTopLevelCanvas()
             {
                 var canvas = this.GetComponentInParent<Canvas>();

--- a/Runtime/SafeAreaPadding/SafeAreaPadding.cs
+++ b/Runtime/SafeAreaPadding/SafeAreaPadding.cs
@@ -117,7 +117,7 @@ namespace E7.NotchSolution
 #endif
 
         //INotchSimulatorTarget
-        public void SimulatorUpdate(Rect simulatedSafeArea)
+        public void SimulatorUpdate(Rect simulatedSafeArea, Rect[] simulatedCutouts)
         {
             UpdateRect();
         }


### PR DESCRIPTION
Adds a partial support of the notches (#2): the information on these is now available, it remains only to use them for the layout (easier said than done ...)
The debug scene displays the simulated device information so that you can easily see where the items are and thus verify your configuration.
The rect returned by the debug scene is now forced to match the rect in portrait or landscape mode to avoid confusion when copying (does not work for now with the option of reversing the orientation of the editor).
Sometimes the model was not displayed or was unusually small when I changed the size of the game view.