### PR TITLE
fixed safe area wrong on pixel 4 XL

### DIFF
--- a/Runtime/Components/SafePadding.cs
+++ b/Runtime/Components/SafePadding.cs
@@ -91,10 +91,32 @@ namespace E7.NotchSolution
                 1 - (safeAreaRelative.yMin + safeAreaRelative.height),
                 1 - (safeAreaRelative.xMin + safeAreaRelative.width),
             };
-
+			
 #if DEBUG_NOTCH_SOLUTION
             Debug.Log($"SafeLDUR {string.Join(" ", relativeLDUR.Select(x => x.ToString()))}");
 #endif
+
+			// fixed: sometimes relativeLDUR will be NAN when start at some android devices. 
+			// if relativeLDUR is NAN then sizeDelta will be NAN, the safe area will be wrong.
+			if (float.IsNaN(relativeLDUR[0]))
+            {
+                relativeLDUR[0] = 0;
+            }
+
+            if (float.IsNaN(relativeLDUR[1]))
+            {
+                relativeLDUR[1] = 0;
+            }
+
+            if (float.IsNaN(relativeLDUR[2]))
+            {
+                relativeLDUR[2] = 0;
+            }
+
+            if (float.IsNaN(relativeLDUR[3]))
+            {
+                relativeLDUR[3] = 0;
+            }
 
             var currentRect = rectTransform.rect;
 


### PR DESCRIPTION
I get a wrong safe area on pixel 4 XL.

The reason is the safe area values are NAN when app start. And then the recttransform will be set some wrong value.

I added some defense codes，let the size will not be too much wrong.

It is work on my pixel 4 XL.