### PR TITLE
Notch Simulator automatically resizes Game window and configurable device orientation in Notch Simulator Window

### DIFF
--- a/Editor/Settings/Settings.cs
+++ b/Editor/Settings/Settings.cs
@@ -20,8 +20,9 @@ namespace E7.NotchSolution.Editor
         [SerializeField] private List<PerPlatformConfigurations> perPlatformConfigurations;
 
         [field: SerializeField] internal bool EnableSimulation { get; set; }
-        [field: SerializeField] internal bool FlipOrientation { get; set; }
         [field: SerializeField] internal Color PrefabModeOverlayColor { get; set; }
+
+        internal bool FlipOrientation { get { return ActiveConfiguration.Orientation == PreviewOrientation.LandscapeRight || ActiveConfiguration.Orientation == PreviewOrientation.PortraitUpsideDown; } }
 
         public Settings()
         {

--- a/Editor/Simulator/GameViewResolution.cs
+++ b/Editor/Simulator/GameViewResolution.cs
@@ -1,0 +1,265 @@
+﻿using System;
+using System.Reflection;
+using UnityEditor;
+using UnityEngine;
+
+namespace E7.NotchSolution.Editor
+{
+	public static class GameViewResolution
+	{
+		private const string TEMPORARY_RESOLUTION_LABEL = "Notch Simulator Device";
+		private const string PREVIOUS_RESOLUTION_PREF = "NotchSimPrevRes";
+
+		private static object GameViewSizes { get { return GetType( "GameViewSizes" ).FetchProperty( "instance" ).FetchProperty( "currentGroup" ); } }
+
+		private static object FixedResolutionMode { get { return Enum.Parse( GetType( "GameViewSizeType" ), "FixedResolution" ); } }
+		private static object AspectRatioMode { get { return Enum.Parse( GetType( "GameViewSizeType" ), "AspectRatio" ); } }
+
+		private static object m_customResolution;
+		private static object CustomResolution
+		{
+			get
+			{
+				if( m_customResolution != null )
+				{
+					if( (int) GameViewSizes.CallMethod( "IndexOf", m_customResolution ) < 0 )
+						m_customResolution = null;
+				}
+				else
+				{
+					int totalSizeCount = (int) GameViewSizes.CallMethod( "GetTotalCount" );
+					int builtinSizeCount = (int) GameViewSizes.CallMethod( "GetBuiltinCount" );
+					for( int i = totalSizeCount - 1; i >= builtinSizeCount; i-- )
+					{
+						object size = GameViewSizes.CallMethod( "GetGameViewSize", i );
+						if( (string) size.FetchProperty( "baseText" ) == TEMPORARY_RESOLUTION_LABEL )
+						{
+							m_customResolution = size;
+							break;
+						}
+					}
+				}
+
+				return m_customResolution;
+			}
+			set { m_customResolution = value; }
+		}
+
+		private static int CustomResolutionIndex { get { return m_customResolution == null ? -1 : (int) GameViewSizes.CallMethod( "IndexOf", m_customResolution ) + (int) GameViewSizes.CallMethod( "GetBuiltinCount" ); } }
+
+		public static void SetResolution( int width, int height, bool aspectRatioMode )
+		{
+			EditorWindow gameView = GetGameView();
+			if( !gameView )
+			{
+#if UNITY_2019_3_OR_NEWER
+				// On 2019.3 and later, we can resize canvases even when there is no open Game window. On earlier versions, unfortunately it is not possible
+				if( !NotchSolutionUtilityEditor.UnityDeviceSimulatorActive )
+				{
+					SceneView sceneView = SceneView.lastActiveSceneView ?? SceneView.currentDrawingSceneView;
+					if( sceneView )
+					{
+						sceneView.CallMethod( "SetMainPlayModeViewSize", new Vector2( width, height ) );
+						RefreshMockups();
+					}
+				}
+#endif
+
+				return;
+			}
+
+			object customResolution = CustomResolution;
+			if( customResolution != null )
+			{
+				bool isModified = false;
+
+				if( ( customResolution.FetchProperty( "sizeType" ).Equals( AspectRatioMode ) ) != aspectRatioMode )
+				{
+					customResolution.ModifyProperty( "sizeType", aspectRatioMode ? AspectRatioMode : FixedResolutionMode );
+					isModified = true;
+				}
+
+				if( (int) customResolution.FetchProperty( "width" ) != width )
+				{
+					customResolution.ModifyProperty( "width", width );
+					isModified = true;
+				}
+
+				if( (int) customResolution.FetchProperty( "height" ) != height )
+				{
+					customResolution.ModifyProperty( "height", height );
+					isModified = true;
+				}
+
+				if( !isModified )
+					return;
+				else if( CustomResolutionIndex == (int) gameView.FetchProperty( "selectedSizeIndex" ) )
+				{
+					ZoomOutGameView();
+					RefreshMockups();
+
+					return;
+				}
+			}
+			else
+			{
+				CustomResolution = customResolution = GetType( "GameViewSize" ).CreateInstance( aspectRatioMode ? AspectRatioMode : FixedResolutionMode, width, height, TEMPORARY_RESOLUTION_LABEL );
+				GameViewSizes.CallMethod( "AddCustomSize", customResolution );
+			}
+
+			PlayerPrefs.SetInt( PREVIOUS_RESOLUTION_PREF, (int) gameView.FetchProperty( "selectedSizeIndex" ) );
+			gameView.CallMethod( "SizeSelectionCallback", CustomResolutionIndex, null );
+
+			ZoomOutGameView();
+			RefreshMockups();
+		}
+
+		public static void ClearResolution()
+		{
+			if( CustomResolution != null )
+			{
+				EditorWindow gameView = GetGameView();
+				bool customResolutionActive = gameView && CustomResolutionIndex == (int) gameView.FetchProperty( "selectedSizeIndex" );
+
+				GameViewSizes.CallMethod( "RemoveCustomSize", CustomResolutionIndex );
+				CustomResolution = null;
+
+				if( customResolutionActive )
+				{
+					gameView.CallMethod( "SizeSelectionCallback", Mathf.Clamp( PlayerPrefs.GetInt( PREVIOUS_RESOLUTION_PREF ), 0, (int) GameViewSizes.CallMethod( "GetTotalCount" ) - 1 ), null );
+
+					ZoomOutGameView();
+					RefreshMockups();
+				}
+			}
+		}
+
+		private static EditorWindow GetGameView()
+		{
+			UnityEngine.Object[] windows = Resources.FindObjectsOfTypeAll( GetType( "GameView" ) );
+			return windows.Length > 0 ? (EditorWindow) windows[0] : null;
+		}
+
+		private static void ZoomOutGameView()
+		{
+			EditorWindow gameView = GetGameView();
+
+			// Find the currently active tab on Game view's panel
+			EditorWindow activeTab = gameView.FetchField( "m_Parent" )?.FetchProperty( "actualView" ) as EditorWindow;
+
+			gameView.Focus();
+			gameView.CallMethod( "UpdateZoomAreaAndParent" );
+			gameView.CallMethod( "SnapZoom", (float) gameView.FetchProperty( "minScale" ) );
+
+			// Restore the active tab
+			if( activeTab && activeTab != gameView )
+				activeTab.Focus();
+		}
+
+		private static int mockupRefreshTime;
+
+		private static void RefreshMockups()
+		{
+			// Sometimes we need to respawn the mockups after a couple of frames in order to synchronize the mockups
+			// with the new game view resolution
+			if( !NotchSimulator.IsOpen )
+			{
+				mockupRefreshTime = 2;
+
+				EditorApplication.update -= RefreshMockupsInternal;
+				EditorApplication.update += RefreshMockupsInternal;
+			}
+		}
+
+		private static void RefreshMockupsInternal()
+		{
+			if( --mockupRefreshTime <= 0 )
+			{
+				EditorApplication.update -= RefreshMockupsInternal;
+				NotchSimulator.RespawnMockup();
+			}
+		}
+
+		#region Reflection Functions
+		private static Type GetType( string type )
+		{
+			return typeof( EditorWindow ).Assembly.GetType( "UnityEditor." + type );
+		}
+
+		private static object FetchField( this Type type, string field )
+		{
+			return type.GetFieldRecursive( field, true ).GetValue( null );
+		}
+
+		private static object FetchField( this object obj, string field )
+		{
+			return obj.GetType().GetFieldRecursive( field, false ).GetValue( obj );
+		}
+
+		private static object FetchProperty( this Type type, string property )
+		{
+			return type.GetPropertyRecursive( property, true ).GetValue( null, null );
+		}
+
+		private static object FetchProperty( this object obj, string property )
+		{
+			return obj.GetType().GetPropertyRecursive( property, false ).GetValue( obj, null );
+		}
+
+		private static void ModifyProperty( this object obj, string property, object value )
+		{
+			obj.GetType().GetPropertyRecursive( property, false ).SetValue( obj, value, null );
+		}
+
+		private static object CallMethod( this object obj, string method, params object[] parameters )
+		{
+			return obj.GetType().GetMethod( method, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance ).Invoke( obj, parameters );
+		}
+
+		private static object CreateInstance( this Type type, params object[] parameters )
+		{
+			Type[] parameterTypes;
+			if( parameters == null )
+				parameterTypes = null;
+			else
+			{
+				parameterTypes = new Type[parameters.Length];
+				for( int i = 0; i < parameters.Length; i++ )
+					parameterTypes[i] = parameters[i].GetType();
+			}
+
+			return type.GetConstructor( parameterTypes ).Invoke( parameters );
+		}
+
+		private static FieldInfo GetFieldRecursive( this Type type, string field, bool isStatic )
+		{
+			BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly | ( isStatic ? BindingFlags.Static : BindingFlags.Instance );
+			do
+			{
+				FieldInfo fieldInfo = type.GetField( field, flags );
+				if( fieldInfo != null )
+					return fieldInfo;
+
+				type = type.BaseType;
+			} while( type != null );
+
+			return null;
+		}
+
+		private static PropertyInfo GetPropertyRecursive( this Type type, string property, bool isStatic )
+		{
+			BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly | ( isStatic ? BindingFlags.Static : BindingFlags.Instance );
+			do
+			{
+				PropertyInfo propertyInfo = type.GetProperty( property, flags );
+				if( propertyInfo != null )
+					return propertyInfo;
+
+				type = type.BaseType;
+			} while( type != null );
+
+			return null;
+		}
+		#endregion
+	}
+}

--- a/Editor/Simulator/GameViewResolution.cs.meta
+++ b/Editor/Simulator/GameViewResolution.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f35e2ac1ee0087741937a773d3ca6667
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Simulator/NotchSimulator.cs
+++ b/Editor/Simulator/NotchSimulator.cs
@@ -25,6 +25,8 @@ namespace E7.NotchSolution.Editor
         private static NotchSimulator win;
         private static Vector2 gameviewResolution;
 
+        private Vector2 scrollPos;
+
         internal static bool IsOpen { get { return win; } }
 
         [MenuItem("Window/General/Notch Simulator")]
@@ -121,6 +123,7 @@ namespace E7.NotchSolution.Editor
             //Sometimes even with flag I can see it in hierarchy until I move a mouse over it??
             EditorApplication.RepaintHierarchyWindow();
 
+            scrollPos = EditorGUILayout.BeginScrollView(scrollPos);
             EditorGUI.BeginChangeCheck();
 
             var settings = Settings.Instance;
@@ -152,6 +155,14 @@ namespace E7.NotchSolution.Editor
             //Draw warning about wrong aspect ratio
             if (settings.EnableSimulation && simulationDevice != null)
             {
+#if !UNITY_2019_3_OR_NEWER
+                if (!NotchSolutionUtilityEditor.PlayModeViewOpen)
+                    EditorGUILayout.HelpBox("Device preview won't resize automatically because Game window isn't open.", MessageType.Warning);
+#else
+                if (NotchSolutionUtilityEditor.UnityDeviceSimulatorActive)
+                    EditorGUILayout.HelpBox("Device preview won't resize automatically because Unity Device Simulator window is open.", MessageType.Warning);
+#endif
+
                 ScreenOrientation gameViewOrientation = NotchSimulatorUtility.GetGameViewOrientation();
 
                 Vector2 gameViewSize = NotchSimulatorUtility.GetMainGameViewSize();
@@ -179,6 +190,8 @@ namespace E7.NotchSolution.Editor
                 UpdateAllMockups();
                 settings.Save();
             }
+
+            EditorGUILayout.EndScrollView();
 
             UpdateSimulatorTargets();
         }

--- a/Editor/Simulator/NotchSimulatorConfiguration.cs
+++ b/Editor/Simulator/NotchSimulatorConfiguration.cs
@@ -3,6 +3,9 @@ using UnityEngine;
 
 namespace E7.NotchSolution.Editor
 {
+    public enum PreviewOrientation { Portrait, PortraitUpsideDown, LandscapeLeft, LandscapeRight };
+    public enum GameViewSizePolicy { MatchResolution, MatchAspectRatio };
+
     /// <summary>
     /// Notch Solution can be in only 1 configuration at any point.
     /// </summary>
@@ -16,6 +19,16 @@ namespace E7.NotchSolution.Editor
         /// The device selected when linearize the simulator database and count from the beginning.
         /// </summary>
         [field: SerializeField] internal int DeviceIndex { get; set; }
+
+        /// <summary>
+        /// Screen orientation of the preview device.
+        /// </summary>
+        [field: SerializeField] internal PreviewOrientation Orientation { get; set; }
+
+        /// <summary>
+        /// Whether the game view's size should match the device's exact resolution or only its aspect ratio.
+        /// </summary>
+        [field: SerializeField] internal GameViewSizePolicy GameViewSize { get; set; }
 
         public NotchSimulatorConfiguration(string configurationName)
         {

--- a/Editor/Simulator/NotchSimulatorUtility.cs
+++ b/Editor/Simulator/NotchSimulatorUtility.cs
@@ -73,7 +73,19 @@ namespace E7.NotchSolution.Editor
         internal static Vector2 GetMainGameViewSize()
         {
 #if UNITY_2019_3_OR_NEWER
-            return (Vector2)GetSizeOfMainGameView.Invoke(null, null);
+            Vector2 result = (Vector2)GetSizeOfMainGameView.Invoke(null, null);
+            if (result == new Vector2(640f, 480f) && !NotchSolutionUtilityEditor.PlayModeViewOpen)
+			{
+                // Neither Game window nor Unity Device Simulator window is open (can happen if Scene view is maximized)
+                // In this case, the last open game window's size can be determined by looking at the mockup canvas' size
+                foreach (MockupCanvas mockupCanvas in NotchSimulator.AllMockupCanvases)
+				{
+                    result = ((RectTransform) mockupCanvas.GetComponent<Canvas>().transform).sizeDelta;
+                    break;
+				}
+			}
+
+            return result;
 #else
             System.Object Res = GetSizeOfMainGameView.Invoke(null, argsForOut);
             return (Vector2)argsForOut[0];

--- a/Runtime/Base/NotchSolutionUIBehaviourBase.cs
+++ b/Runtime/Base/NotchSolutionUIBehaviourBase.cs
@@ -21,9 +21,9 @@ namespace E7.NotchSolution
     [RequireComponent(typeof(RectTransform))]
     public abstract class NotchSolutionUIBehaviourBase : UIBehaviour, ILayoutSelfController, INotchSimulatorTarget
     {
-        private protected abstract void UpdateRect();
+        protected abstract void UpdateRect();
 
-        private protected Rect GetCanvasRect()
+        protected Rect GetCanvasRect()
         {
             var topLevelCanvas = GetTopLevelCanvas();
             Vector2 topRectSize = topLevelCanvas.GetComponent<RectTransform>().sizeDelta;
@@ -53,7 +53,7 @@ namespace E7.NotchSolution
 
         [System.NonSerialized]
         private RectTransform m_Rect;
-        private protected RectTransform rectTransform
+        protected RectTransform rectTransform
         {
             get
             {
@@ -63,7 +63,7 @@ namespace E7.NotchSolution
             }
         }
 
-        private protected DrivenRectTransformTracker m_Tracker;
+        protected DrivenRectTransformTracker m_Tracker;
 
         /// <summary>
         /// Overrides <see cref="UIBehaviour"/>

--- a/Runtime/Base/NotchSolutionUtilityEditor.cs
+++ b/Runtime/Base/NotchSolutionUtilityEditor.cs
@@ -15,9 +15,17 @@ namespace E7.NotchSolution
 #if UNITY_EDITOR
 
 #if UNITY_2019_3_OR_NEWER
-        static System.Type T = System.Type.GetType("UnityEditor.PlayModeView,UnityEditor");
-        static System.Reflection.MethodInfo GetMainPlayModeView = T.GetMethod("GetMainPlayModeView", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        internal static System.Reflection.MethodInfo GetMainPlayModeView = System.Type.GetType("UnityEditor.PlayModeView,UnityEditor").GetMethod("GetMainPlayModeView", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+#else
+        internal static System.Reflection.MethodInfo GetMainPlayModeView = System.Type.GetType("UnityEditor.GameView,UnityEditor").GetMethod("GetMainGameView", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+#endif
 
+        /// <summary>
+        /// Returns true if Game window, Unity Device Simulator window or any other PlayModeView window is open in the Editor.
+        /// </summary>
+        internal static bool PlayModeViewOpen { get { return GetMainPlayModeView.Invoke(null, null) as EditorWindow; } }
+
+#if UNITY_2019_3_OR_NEWER
         /// <summary>
         /// With [Device Simulator](https://docs.unity3d.com/Packages/com.unity.device-simulator@latest) installed it can use a secondary
         /// game view (also a new internal feature in 2019.3) and take control of the screen size and etc. If we detect that active, disable our
@@ -27,6 +35,9 @@ namespace E7.NotchSolution
         {
             get
             {
+                if (!PlayModeViewOpen)
+                    return false;
+
                 var mainPlayModeView = GetMainPlayModeView.Invoke(null,null);
                 var name = mainPlayModeView.GetType().FullName;
                 //I am lazy so I will simply do a class name check with the one in that package.

--- a/Runtime/Components/SafePadding.cs
+++ b/Runtime/Components/SafePadding.cs
@@ -40,7 +40,7 @@ namespace E7.NotchSolution
         [SerializeField] bool flipPadding = false;
 #pragma warning restore 0649
 
-        private protected override void UpdateRect()
+        protected override void UpdateRect()
         {
             PerEdgeEvaluationModes selectedOrientation =
             orientationType == SupportedOrientations.Dual ?


### PR DESCRIPTION
Addressed issues:

- https://github.com/5argon/NotchSolution/issues/46
- https://github.com/5argon/NotchSolution/issues/53

Note that in the following 2 cases, Game window won't/can't be resized via Notch Simulator:

- when Unity Device Simulator is open
- when Game window isn't open on Unity 2019.2 or earlier (i.e. when Scene window is maximized)

The updated Notch Simulator window:

![NotchSimulatorWindow](https://user-images.githubusercontent.com/10211608/101347411-1ba7cc00-389b-11eb-81ac-0f062dba2130.gif)
