### PR TITLE
Fix GC allocation (96 byte)

### DIFF
--- a/Runtime/Components/SafePadding.cs
+++ b/Runtime/Components/SafePadding.cs
@@ -84,13 +84,13 @@ namespace E7.NotchSolution
             Debug.Log($"Top {topRect} safe {safeAreaRelative} min {safeAreaRelative.xMin} {safeAreaRelative.yMin}");
 #endif
 
-            var relativeLDUR = new float[4]
-            {
+            var relativeLDUR = new Vector4(
+            
                 safeAreaRelative.xMin,
                 safeAreaRelative.yMin,
                 1 - (safeAreaRelative.yMin + safeAreaRelative.height),
-                1 - (safeAreaRelative.xMin + safeAreaRelative.width),
-            };
+                1 - (safeAreaRelative.xMin + safeAreaRelative.width)
+            );
 			
 #if DEBUG_NOTCH_SOLUTION
             Debug.Log($"SafeLDUR {string.Join(" ", relativeLDUR.Select(x => x.ToString()))}");
@@ -121,10 +121,7 @@ namespace E7.NotchSolution
             var currentRect = rectTransform.rect;
 
             //TODO : Calculate the current padding relative, to enable "Unlocked" mode. (Not forcing zero padding)
-            var finalPaddingsLDUR = new float[4]
-            {
-                0,0,0,0
-            };
+            var finalPaddingsLDUR = new Vector4();
 
             switch (selectedOrientation.left)
             {


### PR DESCRIPTION
For ScreenSpace Camera, this is called every update and therefore creates quite some garbage. There are 32 byte remaining, but those are only allocated in the editor.

To reproduce, create a screenspace camera canvas with a child with the safe padding script.
![grafik](https://user-images.githubusercontent.com/4518980/105739838-7a4f0500-5f30-11eb-87b5-0c65e940201d.png)


This PR does not fix the call every update, but the allocations resulting from those frequent calls. It might be worth taking a look, why the update is fired every frame.