### PR TITLE
Gracefully handle a null mockupImage on reload

### DIFF
--- a/Runtime/Base/MockupCanvas.cs
+++ b/Runtime/Base/MockupCanvas.cs
@@ -18,6 +18,9 @@ namespace E7.NotchSolution
 
         public void UpdateMockupSprite(Sprite sprite, ScreenOrientation orientation, bool simulate, bool flipped, Color prefabModeOverlayColor)
         {
+            if(mockupImage == null)
+                return;
+                
             if (!simulate)
             {
                 mockupImage.enabled = false;


### PR DESCRIPTION
For whatever reason the mockupImage can be null for me sometimes, so best to just handle it gracefully as it doesn't actually seem to break anything but is pretty annoying when you're script editing and see an error flag up