### PR TITLE
Fix safe area calculations for Unity Standalone builds

### DIFF
--- a/Runtime/Base/NotchSolutionUtility.cs
+++ b/Runtime/Base/NotchSolutionUtility.cs
@@ -65,8 +65,13 @@ namespace E7.NotchSolution
 
         private static Rect ToScreenRelativeRect(Rect absoluteRect)
         {
+#if UNITY_STANDALONE
+            var w = absoluteRect.width;
+            var h = absoluteRect.height;
+#else
             int w = Screen.currentResolution.width;
             int h = Screen.currentResolution.height;
+#endif
             //Debug.Log($"{w} {h} {Screen.currentResolution} {absoluteRect}");
             return new Rect(
                 absoluteRect.x / w,


### PR DESCRIPTION
Standalone builds aren't necessarily fullscreen so we really only want to use the size of the player.