### PR TITLE
Handle new Unity Device Simulator window name

### DIFF
--- a/Runtime/Base/NotchSolutionUtilityEditor.cs
+++ b/Runtime/Base/NotchSolutionUtilityEditor.cs
@@ -2,6 +2,7 @@
 using UnityEditor;
 #endif
 
+using System.Text.RegularExpressions;
 using UnityEngine;
 
 namespace E7.NotchSolution
@@ -30,7 +31,7 @@ namespace E7.NotchSolution
                 var mainPlayModeView = GetMainPlayModeView.Invoke(null,null);
                 var name = mainPlayModeView.GetType().FullName;
                 //I am lazy so I will simply do a class name check with the one in that package.
-                return name == "Unity.DeviceSimulator.SimulatorWindow";
+                return Regex.IsMatch(name, "Unity(Editor).DeviceSimulat(ion|or).SimulatorWindow");
             }
         }
 #endif


### PR DESCRIPTION
In newer versions of the Unity Device Simulator package, the Editor window class name has changed from `Unity.DeviceSimulator.SimulatorWindow` to `UnityEditor.DeviceSimulation.SimulatorWindow`. This closes #61 