### PR TITLE
Updated the code to work with Unity API version 2021.3

### DIFF
--- a/Editor/Simulator/NotchSimulator.cs
+++ b/Editor/Simulator/NotchSimulator.cs
@@ -8,7 +8,6 @@ using UnityEditor;
 using UnityEditor.Build;
 using UnityEditor.Build.Reporting;
 using UnityEditor.Callbacks;
-using UnityEditor.Experimental.SceneManagement;
 using UnityEditor.SceneManagement;
 using UnityEditor.ShortcutManagement;
 using UnityEngine;
@@ -153,7 +152,7 @@ namespace E7.NotchSolution.Editor
                 var gameViewOrientation = NotchSimulatorUtility.GetGameViewOrientation();
 
                 var gameViewSize = NotchSimulatorUtility.GetMainGameViewSize();
-                if (gameViewOrientation == ScreenOrientation.Landscape)
+                if (gameViewOrientation == ScreenOrientation.LandscapeLeft)
                 {
                     var flip = gameViewSize.x;
                     gameViewSize.x = gameViewSize.y;

--- a/Editor/Simulator/NotchSimulatorUtility.cs
+++ b/Editor/Simulator/NotchSimulatorUtility.cs
@@ -21,7 +21,7 @@ namespace E7.NotchSolution.Editor
             var orientation = GetGameViewOrientation();
             var safe = firstScreen.orientations[orientation].safeArea;
             var screenSize = new Vector2(firstScreen.width, firstScreen.height);
-            if (orientation == ScreenOrientation.Landscape)
+            if (orientation == ScreenOrientation.LandscapeLeft)
             {
                 var swap = screenSize.x;
                 screenSize.x = screenSize.y;
@@ -48,7 +48,7 @@ namespace E7.NotchSolution.Editor
             }
 
             var screenSize = new Vector2(firstScreen.width, firstScreen.height);
-            if (orientation == ScreenOrientation.Landscape)
+            if (orientation == ScreenOrientation.LandscapeLeft)
             {
                 var swap = screenSize.x;
                 screenSize.x = screenSize.y;
@@ -86,7 +86,7 @@ namespace E7.NotchSolution.Editor
         internal static ScreenOrientation GetGameViewOrientation()
         {
             var gameViewSize = GetMainGameViewSize();
-            return gameViewSize.x > gameViewSize.y ? ScreenOrientation.Landscape : ScreenOrientation.Portrait;
+            return gameViewSize.x > gameViewSize.y ? ScreenOrientation.LandscapeLeft : ScreenOrientation.Portrait;
         }
 
 #if UNITY_2019_3_OR_NEWER

--- a/Runtime/Base/Adaptation/AdaptationBase.cs
+++ b/Runtime/Base/Adaptation/AdaptationBase.cs
@@ -20,7 +20,7 @@ namespace E7.NotchSolution
 
         private BlendedClipsAdaptor SelectedAdaptation =>
             supportedOrientations == SupportedOrientations.Dual
-                ? NotchSolutionUtility.GetCurrentOrientation() == ScreenOrientation.Landscape ? landscapeAdaptation :
+                ? NotchSolutionUtility.GetCurrentOrientation() == ScreenOrientation.LandscapeLeft ? landscapeAdaptation :
                 portraitOrDefaultAdaptation
                 : portraitOrDefaultAdaptation;
 

--- a/Runtime/Base/MockupCanvas.cs
+++ b/Runtime/Base/MockupCanvas.cs
@@ -48,7 +48,7 @@ namespace E7.NotchSolution
                 }
 
                 mockupImage.transform.rotation =
-                    Quaternion.Euler(0, 0, orientation == ScreenOrientation.Landscape ? 90 : 0);
+                    Quaternion.Euler(0, 0, orientation == ScreenOrientation.LandscapeLeft ? 90 : 0);
                 mockupImage.sprite = sprite;
                 mockupImage.transform.localScale = new Vector3(
                     flipped ? -1 : 1,

--- a/Runtime/Base/NotchSolutionUtility.cs
+++ b/Runtime/Base/NotchSolutionUtility.cs
@@ -97,7 +97,7 @@ namespace E7.NotchSolution
 
         internal static ScreenOrientation GetCurrentOrientation()
         {
-            return Screen.width > Screen.height ? ScreenOrientation.Landscape : ScreenOrientation.Portrait;
+            return Screen.width > Screen.height ? ScreenOrientation.LandscapeLeft : ScreenOrientation.Portrait;
         }
 
         private static Rect ToScreenRelativeRect(Rect absoluteRect)

--- a/Runtime/Components/SafePadding.cs
+++ b/Runtime/Components/SafePadding.cs
@@ -42,7 +42,7 @@ namespace E7.NotchSolution
         {
             var selectedOrientation =
                 orientationType == SupportedOrientations.Dual
-                    ? NotchSolutionUtility.GetCurrentOrientation() == ScreenOrientation.Landscape ? landscapePaddings :
+                    ? NotchSolutionUtility.GetCurrentOrientation() == ScreenOrientation.LandscapeLeft ? landscapePaddings :
                     portraitOrDefaultPaddings
                     : portraitOrDefaultPaddings;
 


### PR DESCRIPTION
The enum member `ScreenOrientation.Landscape` has been removed from Unity 2021.3. To compile the Notch Solution plugin in the Unity Editor 2021.3, one as to change the code depending on the mentioned API change.

Note: the logic depending on the actual screen orientation works independently of the fact that the screen orientation is landscape left or right, i.e. the only relevant thing to know is if the actual screen orientation is either landscape (left or right) or portrait (normal or upside down). Thus there's no need to write such checks in the code:
`if (orientation == ScreenOrientation.LandscapeLeft || orientation == ScreenOrientation.LandscapeRight)`