### PR TITLE
Add null check to ensure that errors aren't thrown when entering playmode

### DIFF
--- a/Runtime/Base/NotchSolutionUIBehaviourBase.cs
+++ b/Runtime/Base/NotchSolutionUIBehaviourBase.cs
@@ -137,6 +137,7 @@ namespace E7.NotchSolution
                 void DelayedEditorUpdate()
                 {
                     UnityEditor.EditorApplication.update -= DelayedEditorUpdate;
+                    if (this == null) return;
                     UpdateRectBase();
                 };
             }

--- a/Runtime/Components/SafePadding.cs
+++ b/Runtime/Components/SafePadding.cs
@@ -228,10 +228,10 @@ namespace E7.NotchSolution
         private SupportedOrientations orientationType;
 
         [SerializeField]
-        private PerEdgeEvaluationModes portraitOrDefaultPaddings;
+        private PerEdgeEvaluationModes portraitOrDefaultPaddings = new PerEdgeEvaluationModes();
 
         [SerializeField]
-        private PerEdgeEvaluationModes landscapePaddings;
+        private PerEdgeEvaluationModes landscapePaddings = new PerEdgeEvaluationModes();
 
         [Tooltip("Scale down the resulting value read from an edge to be less than an actual value.")]
         [SerializeField] [Range(0f, 1f)]

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "com.e7.notch-solution",
     "author": "Exceed7 Experiments",
     "displayName": "Notch Solution",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "unity": "2019.4",
     "keywords": [
         "ui",


### PR DESCRIPTION
When entering play mode, there were errors that the item no longer existed as it was called during reload,
I simply added a null check prior to calling the offending code
I added the null check there as it seems to only occur in editor, so it avoids the expensive check in runtime