### PR TITLE
Add minimumPadding support to SafePadding component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Documentation~.zip
 Documentation~.zip.meta
 Samples~.zip
 Samples~.zip.meta
+.idea/

--- a/Editor/Drawers/SafePaddingDrawer.cs
+++ b/Editor/Drawers/SafePaddingDrawer.cs
@@ -14,6 +14,7 @@ namespace E7.NotchSolution.Editor
             var landscape = serializedObject.FindProperty("landscapePaddings");
             var influence = serializedObject.FindProperty("influence");
             var flipPadding = serializedObject.FindProperty("flipPadding");
+            var minimumPadding = serializedObject.FindProperty("minimumPadding");
 
             var (landscapeCompatible, portraitCompatible) =
                 NotchSolutionUtilityEditor.GetOrientationCompatibility();
@@ -64,6 +65,7 @@ namespace E7.NotchSolution.Editor
             EditorGUILayout.Separator();
             EditorGUILayout.PropertyField(influence);
             EditorGUILayout.PropertyField(flipPadding);
+            EditorGUILayout.PropertyField(minimumPadding);
 
             serializedObject.ApplyModifiedProperties();
         }

--- a/Runtime/Components/SafePadding.cs
+++ b/Runtime/Components/SafePadding.cs
@@ -177,6 +177,19 @@ namespace E7.NotchSolution
             finalPaddingsLDUR[1] *= influence;
             finalPaddingsLDUR[2] *= influence;
             finalPaddingsLDUR[3] *= influence;
+            
+            if (minimumPadding != null)
+            {
+                //Apply minimum padding if it is set.
+                finalPaddingsLDUR[0] = selectedOrientation.left == EdgeEvaluationMode.Off 
+                    ? 0 : Mathf.Max(finalPaddingsLDUR[0], minimumPadding.left);
+                finalPaddingsLDUR[1] = selectedOrientation.bottom == EdgeEvaluationMode.Off 
+                    ? 0 : Mathf.Max(finalPaddingsLDUR[1], minimumPadding.bottom);
+                finalPaddingsLDUR[2] = selectedOrientation.top == EdgeEvaluationMode.Off 
+                    ? 0 : Mathf.Max(finalPaddingsLDUR[2], minimumPadding.top);
+                finalPaddingsLDUR[3] = selectedOrientation.right == EdgeEvaluationMode.Off 
+                    ? 0 : Mathf.Max(finalPaddingsLDUR[3], minimumPadding.right);
+            }
 
             if (flipPadding)
             {
@@ -241,6 +254,9 @@ namespace E7.NotchSolution
             "The value read from all edges are applied to the opposite side of a RectTransform instead. Useful when you have rotated or negatively scaled RectTransform.")]
         [SerializeField]
         private bool flipPadding;
+        
+        [SerializeField]
+        private PerEdgeValues<float> minimumPadding;
 #pragma warning restore 0649
     }
 }


### PR DESCRIPTION
Introduced a new minimumPadding field to SafePadding, allowing users to specify minimum padding values per edge. Updated the editor drawer to expose this property and modified the runtime logic to enforce these minimums when calculating final paddings.