### PR TITLE
Fix not respecting Device Simulator safearea in Standalone Editor mode

### DIFF
--- a/Runtime/Base/NotchSolutionUtility.cs
+++ b/Runtime/Base/NotchSolutionUtility.cs
@@ -102,13 +102,18 @@ namespace E7.NotchSolution
 
         private static Rect ToScreenRelativeRect(Rect absoluteRect)
         {
-#if UNITY_STANDALONE
-            var w = absoluteRect.width;
-            var h = absoluteRect.height;
-#else
-            int w = Screen.currentResolution.width;
-            int h = Screen.currentResolution.height;
-#endif
+            float w = Screen.currentResolution.width;
+            float h = Screen.currentResolution.height;
+            #if UNITY_STANDALONE && UNITY_EDITOR
+                if (!NotchSolutionUtilityEditor.UnityDeviceSimulatorActive) {
+                    w = absoluteRect.width;
+                    h = absoluteRect.height;
+                }
+            #elif UNITY_STANDALONE
+                w = absoluteRect.width;
+                h = absoluteRect.height;
+            #endif
+
             //Debug.Log($"{w} {h} {Screen.currentResolution} {absoluteRect}");
             return new Rect(
                 absoluteRect.x / w,

--- a/Runtime/Base/NotchSolutionUtility.cs
+++ b/Runtime/Base/NotchSolutionUtility.cs
@@ -104,15 +104,15 @@ namespace E7.NotchSolution
         {
             float w = Screen.currentResolution.width;
             float h = Screen.currentResolution.height;
-            #if UNITY_STANDALONE && UNITY_EDITOR
-                if (!NotchSolutionUtilityEditor.UnityDeviceSimulatorActive) {
-                    w = absoluteRect.width;
-                    h = absoluteRect.height;
-                }
-            #elif UNITY_STANDALONE
+#if UNITY_STANDALONE && UNITY_EDITOR
+            if (!NotchSolutionUtilityEditor.UnityDeviceSimulatorActive) {
                 w = absoluteRect.width;
                 h = absoluteRect.height;
-            #endif
+            }
+#elif UNITY_STANDALONE
+            w = absoluteRect.width;
+            h = absoluteRect.height;
+#endif
 
             //Debug.Log($"{w} {h} {Screen.currentResolution} {absoluteRect}");
             return new Rect(


### PR DESCRIPTION
In https://github.com/5argon/NotchSolution/pull/60 the ToScreenRelativeRect logic was changed for standalone builds.

However, using the device simulator in the Unity Editor (NotchSolutionUtilityEditor.UnityDeviceSimulatorActive) is still possible even when UNITY_STANDALONE is true, i.e. if you want to check some device simulation without changing your active editor platform.

This adds a guard so that Screen.currentResolution is still used in this case.

The logic is a little clunky because of the preprocessor logic and because we need to account for NotchSolutionUtilityEditor being editor-only; ideally you'd probably create a property that abstracts this logic but I wanted to patch this with as small of a change as possible